### PR TITLE
修复keepalive模式下，large header的处理错误

### DIFF
--- a/src/http/ngx_http_request.c
+++ b/src/http/ngx_http_request.c
@@ -3084,6 +3084,7 @@ ngx_http_set_keepalive(ngx_http_request_t *r)
             }
 
             hc->busy = NULL;
+            hc->nbusy = 0;
         }
 #if (NGX_HTTP_SSL)
     }


### PR DESCRIPTION
此处应该是遗漏了hc->nbusy=0