### PR TITLE
fix segfault using proxy_ssl_asynch and keepalive

### DIFF
--- a/src/http/modules/ngx_http_upstream_keepalive_module.c
+++ b/src/http/modules/ngx_http_upstream_keepalive_module.c
@@ -259,6 +259,9 @@ found:
     c->log = pc->log;
     c->read->log = pc->log;
     c->write->log = pc->log;
+#if (NGX_SSL)
+    c->async->log = pc->log;
+#endif
     c->pool->log = pc->log;
 
     pc->connection = c;
@@ -346,6 +349,11 @@ ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc, void *data,
     if (c->write->timer_set) {
         ngx_del_timer(c->write);
     }
+#if (NGX_SSL)
+    if (c->async->timer_set) {
+        ngx_del_timer(c->async);
+    }
+#endif
 
     c->write->handler = ngx_http_upstream_keepalive_dummy_handler;
     c->read->handler = ngx_http_upstream_keepalive_close_handler;
@@ -355,6 +363,9 @@ ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc, void *data,
     c->log = ngx_cycle->log;
     c->read->log = ngx_cycle->log;
     c->write->log = ngx_cycle->log;
+#if (NGX_SSL)
+    c->async->log = ngx_cycle->log;
+#endif
     c->pool->log = ngx_cycle->log;
 
     item->socklen = pc->socklen;


### PR DESCRIPTION
If the async event handler is ngx_ssl_handshake_async_handler and the
timer expires while the connection is in keepalive saving state,
the connection->log will cause segfault bacause it was changed to
ngx_cycle->log.

The async timer is removed in the keepalive free handler to fix the
problem and set the async event log

Backtrace of coredump is following:

```
0  0x00007fd78981a583 in ngx_http_upstream_ssl_handshake_handler (c=0x7fd789b25d68)
    at src/http/ngx_http_upstream.c:1743
1  0x00007fd7897df5ff in ngx_event_expire_timers () at src/event/ngx_event_timer.c:94
2  0x00007fd7897df1bd in ngx_process_events_and_timers (cycle=0x7fd789b036b0) at src/event/ngx_event.c:261
3  0x00007fd7897e82c8 in ngx_worker_process_cycle (cycle=0x7fd789b036b0, data=<value optimized out>)
    at src/os/unix/ngx_process_cycle.c:767
4  0x00007fd7897e6573 in ngx_spawn_process (cycle=0x7fd789b036b0, proc=0x7fd7897e8250 <ngx_worker_process_cycle>,
    data=0x0, name=0x7fd78987d2cb "worker process", respawn=-3) at src/os/unix/ngx_process.c:199
5  0x00007fd7897e7a40 in ngx_start_worker_processes (cycle=0x7fd789b036b0, n=1, type=-3)
    at src/os/unix/ngx_process_cycle.c:361
6  0x00007fd7897e8ee1 in ngx_master_process_cycle (cycle=0x7fd789b036b0) at src/os/unix/ngx_process_cycle.c:133
7  0x00007fd7897bdafe in main (argc=<value optimized out>, argv=<value optimized out>) at src/core/nginx.c:389
```

nginx -V

```
nginx version: nginx/1.14.2
built by gcc 4.5.2 (Ubuntu/Linaro 4.5.2-8ubuntu4) 
built with OpenSSL 1.1.0h  27 Mar 2018
TLS SNI support enabled
configure arguments: --prefix=/opt/asynch --with-http_ssl_module --with-http_stub_status_module --with-http_v2_module --with-stream --with-stream_ssl_module --with-debug --add-dynamic-module=modules/nginx_qat_module --with-cc-opt='-DNGX_SECURE_MEM -I/opt/qat/QAT1.7/.openssl/include -Wno-error=deprecated-declarations -fno-pie' --with-ld-opt='-Wl,-rpath=/opt/qat/QAT1.7/.openssl/lib -L/opt/qat/QAT1.7/.openssl/lib'
```

Test configuration

```
load_module /opt/asynch/modules/ngx_ssl_engine_qat_module.so;
user  root;
worker_processes 1;
worker_cpu_affinity 10;
worker_rlimit_nofile 1048576;
worker_rlimit_core 500M;
working_directory /root;

ssl_engine {
    use_engine qat;
    default_algorithms RSA,EC,DH,PKEY_CRYPTO;
    qat_engine {
        qat_offload_mode async;
        qat_notify_mode poll;
        qat_poll_mode heuristic;
        qat_shutting_down_release on;
    }
}

events {
}


error_log /opt/asynch/logs/error.log error;

http {
    upstream test_server {
      server 33.0.0.100:443 max_fails=0;
      keepalive 2048;
    }

    server {
      error_log /root/debug.log debug;
      proxy_http_version 1.1;
      listen 192.168.215.200:80 default_server backlog=65535;

      location ~ '' {
        proxy_set_header Host $http_host;
        proxy_pass https://test_server;
        proxy_next_upstream off;
        proxy_set_header Connection "";
        proxy_ssl_asynch on;
      }
    }
}
```