### PR TITLE
Doc: update nginx origin download address to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,14 @@ Please download the QAT driver from the link https://01.org/intel-quickassist-te
 
 ```bash
   git clone https://github.com/intel/asynch_mode_nginx.git
-  wget http://nginx.org/download/nginx-1.18.0.tar.gz
-  tar -xvzf ./nginx-1.18.0.tar.gz
-  diff -Naru -x .git nginx-1.18.0 asynch_mode_nginx > async_mode_nginx_1.18.0.patch
+  git clone -b release-1.18.0 git@github.com:nginx/nginx.git nginx-1.18
+  diff -Naru -x .git -x .hgtags -x README.md -x LICENSE nginx-1.18 asynch_mode_nginx > async_mode_nginx_1.18.0.patch
 ```
 
 * Apply patch to official Nginx-1.18.0.
 
 ```bash
-  wget http://nginx.org/download/nginx-1.18.0.tar.gz
-  tar -xvzf ./nginx-1.18.0.tar.gz
+  git clone -b release-1.18.0 git@github.com:nginx/nginx.git nginx-1.18
   patch -p0 < async_mode_nginx_1.18.0.patch
 ```
 


### PR DESCRIPTION
** Background **
When I use the patch which generate by [this method](https://github.com/intel/asynch_mode_nginx#additional-information), I found there is a error like below:
```
The next patch would create the file nginx-1.18.0/src/os/win32/ngx_user.h,
which already exists!  Assume -R? [n]
Apply anyway? [n]
Skipping patch.
1 out of 1 hunk ignored
```
I found `src/os/win32` has been delete in the NGINX source code from http://nginx.org/download

** Fix **
Update NGINX origin download address to github since the NGINX repo will auto sync from the origin repo