### PR TITLE
bugfix: skip freeing SSL context if SSL is not initialized.

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -183,10 +183,6 @@ ngx_module_t  ngx_core_module = {
 static ngx_uint_t   ngx_show_help;
 static ngx_uint_t   ngx_show_version;
 static ngx_uint_t   ngx_show_configure;
-/* indicate that nginx start without ngx_ssl_init()
- * which will involve OpenSSL configuration file to
- * start OpenSSL engine */
-static ngx_uint_t   ngx_no_ssl_init;
 static u_char      *ngx_prefix;
 static u_char      *ngx_error_log;
 static u_char      *ngx_conf_file;
@@ -243,8 +239,7 @@ main(int argc, char *const *argv)
 
     /* STUB */
 #if (NGX_OPENSSL)
-    if(!ngx_no_ssl_init)
-        ngx_ssl_init(log);
+    ngx_ssl_init(log);
 #endif
 
     /*

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -302,6 +302,10 @@ void ngx_cdecl ngx_ssl_error(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
 void ngx_ssl_cleanup_ctx(void *data);
 ngx_int_t ngx_ssl_async_process_fds(ngx_connection_t *c) ;
 
+
+extern ngx_uint_t  ngx_no_ssl_init;
+
+
 extern int  ngx_ssl_connection_index;
 extern int  ngx_ssl_server_conf_index;
 extern int  ngx_ssl_session_cache_index;


### PR DESCRIPTION
resolves #48 