### PR TITLE
bugfix: nginx crash when running with thread pool.

### DIFF
--- a/src/event/modules/ngx_epoll_module.c
+++ b/src/event/modules/ngx_epoll_module.c
@@ -1005,7 +1005,7 @@ ngx_epoll_process_events(ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
 #if (NGX_SSL)
         aev = c->async;
 
-        if ((revents & EPOLLIN) && aev->active && async) {
+        if ((revents & EPOLLIN) && async && aev->active) {
 
             if (c->async_fd == -1 || aev->instance!= instance) {
                 /*


### PR DESCRIPTION
aev->active may be a NULL pointer