### PR TITLE
Bug fix the switch 'ssl_asynch on/off' of asynch_mode_nginx

### DIFF
--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -794,9 +794,6 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
             return NGX_CONF_ERROR;
         }
 
-        conf->ssl.asynch = conf->enable_asynch;
-
-
     } else if (conf->certificates) {
 
         if (conf->certificate_keys == NULL
@@ -813,6 +810,8 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     } else if (!conf->reject_handshake) {
         return NGX_CONF_OK;
     }
+
+    conf->ssl.asynch = conf->enable_asynch;
 
     if (ngx_ssl_create(&conf->ssl, conf->protocols, conf) != NGX_OK) {
         return NGX_CONF_ERROR;
@@ -1117,22 +1116,10 @@ ngx_http_ssl_enable_asynch(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     char  *rv;
 
-    ngx_flag_t       *pssl, *pssl_asynch;
-
     rv = ngx_conf_set_flag_slot(cf, cmd, conf);
 
     if (rv != NGX_CONF_OK) {
         return rv;
-    }
-
-    /* If ssl_asynch on is configured, then ssl on is configured by default
-     * This will align 'ssl_asynch on;' and 'listen port ssl' diretives
-     * */
-    pssl = (ngx_flag_t *) ((char *)conf + offsetof(ngx_http_ssl_srv_conf_t, enable));
-    pssl_asynch = (ngx_flag_t *) ((char *)conf + cmd->offset);
-
-    if(*pssl_asynch && *pssl != 1) {
-        *pssl = *pssl_asynch;
     }
 
     sscf->file = cf->conf_file->file.name.data;


### PR DESCRIPTION
```
 Configuration:
	 load_module modules/ngx_ssl_engine_qat_module.so;
          ssl_engine{
   			     use_engine qatengine;
			      …….
            }
            http {
                     ssl_asynch  on;
                     ssl_protocols        TLSv1.2;
                     ……
                      server {
       				listen 80; 
        			listen 443 ssl;
        			server_name  test.async.nginx;
       				location / { 
             				root html;
         				index  index.html index.htm;
       				}   
                          }
                }
```

Then, send a request and get a wrong result HTTP/1.1 400 Bad Request.
![image](https://user-images.githubusercontent.com/8085013/179437442-63226b98-85dc-40d2-8b6e-7c50d3cbae3a.png)
By reading the code and nginx docs, I find the switch ssl_asynch is designed  by a similar mechanism to ssl on/off. Maybe we should make sure the above configuration can work.Another reason is that some times there are many server int http block.
![image](https://user-images.githubusercontent.com/8085013/179436835-8f1ed457-7fa9-4106-aadc-291472978915.png)
Test case:
① 
```
load_module modules/ngx_ssl_engine_qat_module.so;
ssl_engine{
        use_engine qatengine;
  	…….
}
http {
      ssl_asynch  on;
      ssl_protocols        TLSv1.2;
      ……
     server {
             listen 80; 
     	     listen 443 ssl;
	     listen 4433 asynch;
       	     server_name  test.async.nginx;
  	     location / { 
            	     root html;
        	     index  index.html index.htm;
            }   
        }
}
```
② 
```
load_module modules/ngx_ssl_engine_qat_module.so;
ssl_engine{
      use_engine qatengine;
   …….
}
http {
      ssl_protocols        TLSv1.2;
      ……
      server {
      	      listen 80; 
      	      listen 443 ssl;
	      listen 4433 asynch;
              server_name  test.async.nginx;
              location / { 
             		root html;
        		index  index.html index.htm;
     	   	 }   
           }
}
```
③ 
```
load_module modules/ngx_ssl_engine_qat_module.so;
ssl_engine{
       use_engine qatengine;
   …….
}
http {
        ssl on;
        ssl_protocols        TLSv1.2;
         ……
server {
       	 listen 80; 
     	 listen 443 ssl;
	listen 4433 asynch;
       	 server_name  test.async.nginx;
       	 location / { 
          		  root html;
        		 index  index.html index.htm;
       	 }   
}
		}

```
④ 
```
load_module modules/ngx_ssl_engine_qat_module.so;
ssl_engine{
     use_engine qatengine;
   …….
}
http {
      ssl on;
      ssl_asynch  on;
      ssl_protocols        TLSv1.2;
……
server {
         listen 80; 
       	 listen 443 ssl;
	 listen 4433 asynch;
         server_name  test.async.nginx;
     	 location / { 
            		 root html;
        		 index  index.html index.htm;
      	  }   
      }
}
```
We get the right result of the test cases blow in ① 、 ② 、③、④
curl -svo /dev/null [https://test.async.nginx:443/index.html](https://test.async.nginx/index.html) --resolve test.async.nginx:443:127.0.0.1 -k
curl -svo /dev/null https://test.async.nginx:4433/index.html --resolve test.async.nginx:4433:127.0.0.1 -k
We also get the right result of test case below in ① and ②
curl -vo /dev/null http://test.async.nginx/index.html -x 127.0.0.1:80  
But because of the switch ssl on/off we can’t get right result in ③ and ④；Maybe we could let it be or fix it in the project “nginx”
curl -vo /dev/null http://test.async.nginx/index.html -x 127.0.0.1:80
![image](https://user-images.githubusercontent.com/8085013/179436875-32792e74-f5b8-4b57-879f-5f7fc0e282d6.png)
